### PR TITLE
Add font-size to root <svg> to support proper rem sizing

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -110,8 +110,29 @@ var render = (function (util, browser, documentHelper, xmlserializer, ayepromise
 
         workAroundCollapsingMarginsAcrossSVGElementInWebKitLike(attributes);
 
+        var fontSize = window.getComputedStyle ?
+            // All modern/decent browsers
+            window.getComputedStyle(doc.documentElement).fontSize :
+            // IE
+            doc.documentElement ?
+                // Standards Mode IE
+                doc.documentElement.currentStyle.fontSize :
+                // Compatibility Mode IE
+                doc.body.currentStyle.fontSize;
+
+        if (!fontSize) {
+          // If the document is detached, getComputedStyle may fail
+          // See https://bugs.webkit.org/show_bug.cgi?id=14563
+          // Fallback to using the font-size declared on the element, if any
+          fontSize = doc.documentElement ?
+              doc.documentElement.style.fontSize :
+              doc.body.style.fontSize;
+        }
+
+        var fontSizeAttr = fontSize ? ' font-size="' + fontSize + '"' : '';
+
         return (
-            '<svg xmlns="http://www.w3.org/2000/svg" width="' + size.width + '" height="' + size.height + '">' +
+            '<svg xmlns="http://www.w3.org/2000/svg" width="' + size.width + '" height="' + size.height + '"' + fontSizeAttr + '>' +
                 '<foreignObject' + serializeAttributes(attributes) + '>' +
                 xhtml +
                 '</foreignObject>' +

--- a/test/specs/RenderSpec.js
+++ b/test/specs/RenderSpec.js
@@ -78,7 +78,7 @@ describe("The rendering process", function () {
             var svgCode = render.getSvgForDocument(doc, aRenderSize(123, 987, 200, 1000, 2, 7), defaultZoomLevel);
 
             expect(svgCode).toMatch(new RegExp(
-                '<svg xmlns="http://www.w3.org/2000/svg" width="123" height="987">' +
+                '<svg xmlns="http://www.w3.org/2000/svg" width="123" height="987"[^>]*>' +
                     '<foreignObject x="-2" y="-7" width="200" height="1000".*>' +
                         '<html xmlns="http://www.w3.org/1999/xhtml">' +
                             '<head>' +
@@ -101,7 +101,7 @@ describe("The rendering process", function () {
             var svgCode = render.getSvgForDocument(doc, aRenderSize(123, 987, 12, 99), zoomFactor);
 
             expect(svgCode).toMatch(new RegExp(
-                '<svg xmlns="http://www.w3.org/2000/svg" width="123" height="987">' +
+                '<svg xmlns="http://www.w3.org/2000/svg" width="123" height="987"[^>]*>' +
                     '<foreignObject x="0" y="0" width="12" height="99" style="-webkit-transform: scale\\(10\\); -webkit-transform-origin: 0 0; transform: scale\\(10\\); transform-origin: 0 0;.*">' +
                         '<html xmlns="http://www.w3.org/1999/xhtml">' +
                             '<head>' +
@@ -124,6 +124,29 @@ describe("The rendering process", function () {
             var svgCode = render.getSvgForDocument(doc, aRenderSize(123, 987), zoomLevel);
 
             expect(svgCode).not.toMatch(new RegExp("scale"));
+        });
+
+        it("should return a SVG with a root font size to preserve rem units", function () {
+            var doc = document.implementation.createHTMLDocument("");
+            doc.documentElement.style.fontSize = "14px";
+            doc.body.innerHTML = "Test content";
+
+            var svgCode = render.getSvgForDocument(doc, aRenderSize(), defaultZoomLevel);
+
+            expect(svgCode).toMatch(new RegExp(
+                '<svg xmlns="http://www.w3.org/2000/svg" [^>]*font-size="14px"[^>]*>' +
+                    '<foreignObject .*>' +
+                        '<html xmlns="http://www.w3.org/1999/xhtml"[^>]*>' +
+                            '<head>' +
+                                '<title(/>|></title>)' +
+                            '</head>' +
+                            '<body>' +
+                                "Test content" +
+                            '</body>' +
+                        '</html>' +
+                    '</foreignObject>' +
+                '</svg>'
+            ));
         });
 
         it("should raise an error on invalid source", function () {


### PR DESCRIPTION
I noticed an issue that the element and font sizing in the rasterized version of some pages is oddly different from the displayed page.  After a bit of investigation, I found that the size of elements with properties specified in [CSS3 rem units](http://www.w3.org/TR/css3-values/#rem-unit) is determined based on the font-size of the root element which, when appearing in an SVG document, this is the root `<svg>` element rather than the `<html>` element which appears inside `<foreignObject>`.

To support such pages, this pull request attempts to copy the font-size from the HTML document root to the SVG document root using `getComputedStyle` with fallback to `currentStyle` and `style` if neither of the others work (to support detached documents, particularly for testing).

I'd appreciate your thoughts on it.  Thanks,
Kevin
