### PR TITLE
readme: bolder claim about lack of support in IE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Renders HTML into the browser's canvas.
 
 See the [API](https://github.com/cburgmer/rasterizeHTML.js/wiki/API).
 
+
 Install
 -------
 
@@ -41,7 +42,11 @@ Limitations
 
 All resources (HTML page, CSS, images, fonts and JS) that are needed for drawing the page can only be loaded if from the [same origin](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Same_origin_policy_for_JavaScript), unless techniques like [CORS](http://enable-cors.org) are used. I.E. `drawURL()` can only load pages from the same domain as the current page and all draw methods can equally only embed styling and images from that domain.
 
-The code is tested under Firefox, Chrome & Safari. There's basic support for Microsoft Edge.
+The code is tested under Firefox, Chrome & Safari.
+
+There's basic support for Microsoft Edge.
+
+**It's not working under [any Internet Explorer version.](https://github.com/cburgmer/rasterizeHTML.js/wiki/Limitations#ie)** 
 
 Also the individual browsers still have some issues when rendering SVGs with embedded HTML to the canvas.
 


### PR DESCRIPTION
Readme was explicitly informing about code being tested in some browsers and implicitly that is working properly.
Explicit information about known lack of IE support is placed in the end of next *.md file, so somewhat hidden.
I'm placing it in readme file linked to "Limitations" doc.