### PR TITLE
fixed zoom bug

### DIFF
--- a/src/document2svg.js
+++ b/src/document2svg.js
@@ -70,9 +70,10 @@ var document2svg = (function (util, browser, documentHelper, mediaQueryHelper, x
                 ' width="' + size.width + '"' +
                 ' height="' + size.height + '"' +
                 ' font-size="' + size.rootFontSize + '"' +
+                serializeAttributes(attributes) +
                 '>' +
                 workAroundChromeShowingScrollbarsUnderLinuxIfHtmlIsOverflowScroll() +
-                '<foreignObject' + serializeAttributes(attributes) + '>' +
+                '<foreignObject>' +
                 xhtml +
                 '</foreignObject>' +
                 '</svg>'


### PR DESCRIPTION
fixed zoom bug

In chrome (my version is 46.0.2490.80 64-bit), the` position relative` element does not change size. In firefox is work. e.g
```html
let html = `
<style>
.box {
  position: relative;
  width: 100px;
  height: 50px;
  background-color: #000;
}
</style>
<div class='box'></div>`;

RasterizeHTML.drawHTML(html, canvas, {zoom: 2});

```
In firefox, the box size is 200px * 100px. In chrome, the box size is 100px * 50px. but we will add  `transform: scale(2)`  atrribute to svg element, no foreignObject element, it is works in both.