### PR TITLE
Calls supportsBlobBuilding()

### DIFF
--- a/src/svg2image.js
+++ b/src/svg2image.js
@@ -71,7 +71,7 @@ var svg2image = (function (window) {
 
     var checkBlobSupport = function () {
         return new Promise(function (resolve, reject) {
-            if (supportsBlobBuilding && window.URL) {
+            if (supportsBlobBuilding() && window.URL) {
                 readingBackFromCanvasBenefitsFromOldSchoolDataUris()
                     .then(function (doesBenefit) {
                         resolve(! doesBenefit);


### PR DESCRIPTION
Calls supportsBlobBuilding() instead of just checking for existence, so that the check for blob building is  really done.