### PR TITLE
Default HTML margin fix

### DIFF
--- a/src/document2svg.js
+++ b/src/document2svg.js
@@ -60,6 +60,10 @@ var document2svg = (function (util, browser, documentHelper, xmlserializer) {
             return '<style scoped="">html::-webkit-scrollbar { display: none; }</style>';
         };
 
+    var workAroundDefaultHtmlMargins = function () {
+        return '<style scoped="">html, body { margin: 0; }</style>';
+    };
+
     var serializeAttributes = function (attributes) {
         var keys = Object.keys(attributes);
         if (!keys.length) {
@@ -94,6 +98,7 @@ var document2svg = (function (util, browser, documentHelper, xmlserializer) {
             serializeAttributes(svgAttributes(size, zoomFactor)) +
             ">" +
             workAroundChromeShowingScrollbarsUnderLinuxIfHtmlIsOverflowScroll() +
+            workAroundDefaultHtmlMargins() +
             "<foreignObject" +
             serializeAttributes(foreignObjectAttrs) +
             ">" +

--- a/test/specs/document2svg.test.js
+++ b/test/specs/document2svg.test.js
@@ -273,6 +273,7 @@ describe("Document to SVG conversion", function () {
                 new RegExp(
                     '<svg xmlns="http://www.w3.org/2000/svg" .*>' +
                         '<style scoped="">html::-webkit-scrollbar { display: none; }</style>' +
+                        '<style scoped="">html, body { margin: 0; }</style>' +
                         "<foreignObject .*>" +
                         ".*" +
                         "</foreignObject>" +


### PR DESCRIPTION
When rendering HTML into foreignObject, its body had a default browser margin which caused inaccurate snapshot.

Off topic:
I was rendering SVG inside my HTML (because I wanted my SVG to work with CSS) and it seems that tool did not calculate content dimensions correctly - it was off by a few pixels even though SVG did not overflow. I have no idea why. To have a perfectly correct rasterized image, would need to look into this as well sometime.