### PR TITLE
Publish library as ESM

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -89,36 +89,21 @@ module.exports = function (grunt) {
         clean: {
             all: ["build", "dist"],
         },
-        umd: {
-            all: {
-                src: "build/rasterizeHTML.concat.js",
-                dest: "build/rasterizeHTML.umd.js",
-                objectToExport: "rasterizeHTML",
-                indent: "    ",
-                deps: {
-                    default: [
-                        "url",
-                        "xmlserializer",
-                        "sanedomparsererror",
-                        "inlineresources",
-                    ],
-                    cjs: [
-                        "url",
-                        "xmlserializer",
-                        "sane-domparser-error",
-                        "inlineresources",
-                    ],
-                    amd: [
-                        "url",
-                        "xmlserializer",
-                        "sane-domparser-error",
-                        "inlineresources",
-                    ],
-                },
+        shell: {
+            rollup: {
+                command: "npx rollup -c",
             },
         },
         concat: {
             one: {
+                options: {
+                    banner:
+                        "import url from 'url';\n" +
+                        "import xmlserializer from 'xmlserializer';\n" +
+                        "import sanedomparsererror from 'sane-domparser-error';\n" +
+                        "import inlineresources from 'inlineresources';\n\n",
+                    footer: "\n\nexport default rasterizeHTML;\n",
+                },
                 src: [
                     "src/util.js",
                     "src/proxies.js",
@@ -131,18 +116,6 @@ module.exports = function (grunt) {
                     "src/index.js",
                 ],
                 dest: "build/rasterizeHTML.concat.js",
-            },
-            dist: {
-                options: {
-                    banner:
-                        "/*! <%= pkg.title || pkg.name %> - v<%= pkg.version %> - " +
-                        '<%= grunt.template.today("yyyy-mm-dd") %>\n' +
-                        "* <%= pkg.homepage %>\n" +
-                        '* Copyright (c) <%= grunt.template.today("yyyy") %> <%= pkg.author.name %>;' +
-                        " Licensed <%= pkg.license %> */\n",
-                },
-                src: ["build/rasterizeHTML.umd.js"],
-                dest: "dist/<%= pkg.title %>",
             },
             types: {
                 options: {
@@ -169,6 +142,7 @@ module.exports = function (grunt) {
                 },
                 files: {
                     "dist/rasterizeHTML.min.js": ["dist/rasterizeHTML.js"],
+                    "dist/rasterizeHTML.min.mjs": ["dist/rasterizeHTML.mjs"],
                 },
             },
             allinone: {
@@ -214,7 +188,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-contrib-watch");
     grunt.loadNpmTasks("grunt-contrib-clean");
     grunt.loadNpmTasks("grunt-browserify");
-    grunt.loadNpmTasks("grunt-umd");
+    grunt.loadNpmTasks("grunt-shell");
 
     grunt.registerTask("deps", [
         "browserify:url",
@@ -226,8 +200,7 @@ module.exports = function (grunt) {
 
     grunt.registerTask("build", [
         "concat:one",
-        "umd",
-        "concat:dist",
+        "shell:rollup",
         "concat:types",
         "browserify:allinone",
         "uglify",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,11 +27,12 @@
         "grunt-contrib-uglify": "^5.0.1",
         "grunt-contrib-watch": "^1.1.0",
         "grunt-eslint": "^26.0.0",
-        "grunt-umd": "^3.0.0",
+        "grunt-shell": "^4.0.0",
         "imagediff": "git://github.com/HumbleSoftware/js-imagediff.git#5edce005fe",
         "jasmine-core": "^5.13.0",
         "prettier": "^3.7.4",
-        "puppeteer": "^24.35.0"
+        "puppeteer": "^24.35.0",
+        "rollup": "^4.40.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -803,6 +804,356 @@
         "streamx": "^2.15.0"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.0.tgz",
+      "integrity": "sha512-tPgXB6cDTndIe1ah7u6amCI1T0SsnlOuKgg10Xh3uizJk4e5M1JGaUMk7J4ciuAUcFpbOiNhm2XIjP9ON0dUqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.0.tgz",
+      "integrity": "sha512-sa4LyseLLXr1onr97StkU1Nb7fWcg6niokTwEVNOO7awaKaoRObQ54+V/hrF/BP1noMEaaAW6Fg2d/CfLiq3Mg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.0.tgz",
+      "integrity": "sha512-/NNIj9A7yLjKdmkx5dC2XQ9DmjIECpGpwHoGmA5E1AhU0fuICSqSWScPhN1yLCkEdkCwJIDu2xIeLPs60MNIVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.0.tgz",
+      "integrity": "sha512-xoh8abqgPrPYPr7pTYipqnUi1V3em56JzE/HgDgitTqZBZ3yKCWI+7KUkceM6tNweyUKYru1UMi7FC060RyKwA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.0.tgz",
+      "integrity": "sha512-PCkMh7fNahWSbA0OTUQ2OpYHpjZZr0hPr8lId8twD7a7SeWrvT3xJVyza+dQwXSSq4yEQTMoXgNOfMCsn8584g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.0.tgz",
+      "integrity": "sha512-1j3stGx+qbhXql4OCDZhnK7b01s6rBKNybfsX+TNrEe9JNq4DLi1yGiR1xW+nL+FNVvI4D02PUnl6gJ/2y6WJA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.0.tgz",
+      "integrity": "sha512-eyrr5W08Ms9uM0mLcKfM/Uzx7hjhz2bcjv8P2uynfj0yU8GGPdz8iYrBPhiLOZqahoAMB8ZiolRZPbbU2MAi6Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.0.tgz",
+      "integrity": "sha512-Xds90ITXJCNyX9pDhqf85MKWUI4lqjiPAipJ8OLp8xqI2Ehk+TCVhF9rvOoN8xTbcafow3QOThkNnrM33uCFQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.0.tgz",
+      "integrity": "sha512-Xws2KA4CLvZmXjy46SQaXSejuKPhwVdaNinldoYfqruZBaJHqVo6hnRa8SDo9z7PBW5x84SH64+izmldCgbezw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.0.tgz",
+      "integrity": "sha512-hrKXKbX5FdaRJj7lTMusmvKbhMJSGWJ+w++4KmjiDhpTgNlhYobMvKfDoIWecy4O60K6yA4SnztGuNTQF+Lplw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.0.tgz",
+      "integrity": "sha512-6A+nccfSDGKsPm00d3xKcrsBcbqzCTAukjwWK6rbuAnB2bHaL3r9720HBVZ/no7+FhZLz/U3GwwZZEh6tOSI8Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.0.tgz",
+      "integrity": "sha512-4P1VyYUe6XAJtQH1Hh99THxr0GKMMwIXsRNOceLrJnaHTDgk1FTcTimDgneRJPvB3LqDQxUmroBclQ1S0cIJwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.0.tgz",
+      "integrity": "sha512-8Vv6pLuIZCMcgXre6c3nOPhE0gjz1+nZP6T+hwWjr7sVH8k0jRkH+XnfjjOTglyMBdSKBPPz54/y1gToSKwrSQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.0.tgz",
+      "integrity": "sha512-r1te1M0Sm2TBVD/RxBPC6RZVwNqUTwJTA7w+C/IW5v9Ssu6xmxWEi+iJQlpBhtUiT1raJ5b48pI8tBvEjEFnFA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.0.tgz",
+      "integrity": "sha512-say0uMU/RaPm3CDQLxUUTF2oNWL8ysvHkAjcCzV2znxBr23kFfaxocS9qJm+NdkRhF8wtdEEAJuYcLPhSPbjuQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.0.tgz",
+      "integrity": "sha512-/MU7/HizQGsnBREtRpcSbSV1zfkoxSTR7wLsRmBPQ8FwUj5sykrP1MyJTvsxP5KBq9SyE6kH8UQQQwa0ASeoQQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.0.tgz",
+      "integrity": "sha512-Q9eh+gUGILIHEaJf66aF6a414jQbDnn29zeu0eX3dHMuysnhTvsUvZTCAyZ6tJhUjnvzBKE4FtuaYxutxRZpOg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.0.tgz",
+      "integrity": "sha512-OR5p5yG5OKSxHReWmwvM0P+VTPMwoBS45PXTMYaskKQqybkS3Kmugq1W+YbNWArF8/s7jQScgzXUhArzEQ7x0A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.0.tgz",
+      "integrity": "sha512-XeatKzo4lHDsVEbm1XDHZlhYZZSQYym6dg2X/Ko0kSFgio+KXLsxwJQprnR48GvdIKDOpqWqssC3iBCjoMcMpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.0.tgz",
+      "integrity": "sha512-Lu71y78F5qOfYmubYLHPcJm74GZLU6UJ4THkf/a1K7Tz2ycwC2VUbsqbJAXaR6Bx70SRdlVrt2+n5l7F0agTUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.0.tgz",
+      "integrity": "sha512-v5xwKDWcu7qhAEcsUubiav7r+48Uk/ENWdr82MBZZRIm7zThSxCIVDfb3ZeRRq9yqk+oIzMdDo6fCcA5DHfMyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.0.tgz",
+      "integrity": "sha512-XnaaaSMGSI6Wk8F4KK3QP7GfuuhjGchElsVerCplUuxRIzdvZ7hRBpLR0omCmw+kI2RFJB80nenhOoGXlJ5TfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.0.tgz",
+      "integrity": "sha512-3K1lP+3BXY4t4VihLw5MEg6IZD3ojSYzqzBG571W3kNQe4G4CcFpSUQVgurYgib5d+YaCjeFow8QivWp8vuSvA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.0.tgz",
+      "integrity": "sha512-MDk610P/vJGc5L5ImE4k5s+GZT3en0KoK1MKPXCRgzmksAMk79j4h3k1IerxTNqwDLxsGxStEZVBqG0gIqZqoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.0.tgz",
+      "integrity": "sha512-Zv7v6q6aV+VslnpwzqKAmrk5JdVkLUzok2208ZXGipjb+msxBr/fJPZyeEXiFgH7k62Ak0SLIfxQRZQvTuf7rQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@sigstore/bundle": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-1.1.0.tgz",
@@ -1189,47 +1540,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/alphabet": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/alphabet/-/alphabet-1.0.0.tgz",
-      "integrity": "sha512-On43lIAQXH/xji0z6ZAqXDvwLKtjn1VFwc7tvv/k0WXv1phlOPul7H+UWnZjNDsMwioAyppH+b74K4UGK/3m9A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/annois": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/annois/-/annois-0.3.2.tgz",
-      "integrity": "sha512-Emt82v8/kzEFmLhqyqtbZcb4OjjCn9LY7FW+xw4DgOG2mPYAscFOCkM5gu5f9jLP7tELW8Gttdaxz0VDpbqLvg==",
-      "dev": true
-    },
-    "node_modules/annotate": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/annotate/-/annotate-0.9.1.tgz",
-      "integrity": "sha512-CM2lmCqBHw+L75Tb8YH3E98CrvgyatfEtdwrA9pEa0JUeoHpvhiJx8zq99ze7JXNStUpnJl7DD+dOapHHQDijg==",
-      "dev": true,
-      "dependencies": {
-        "annois": "0.3.0"
-      }
-    },
-    "node_modules/annotate/node_modules/annois": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/annois/-/annois-0.3.0.tgz",
-      "integrity": "sha512-75o3XxMC8zbrrBp6tloQk3KauIFgH3lVHyGzRfnK+m200lGqGp6ymy9HSbTEhpzy1Tvg/pPRKB7fXUu+cBZggA==",
-      "dev": true
-    },
-    "node_modules/annozip": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/annozip/-/annozip-0.2.6.tgz",
-      "integrity": "sha512-i7+XfWWyZ3NwWKNmw4arC0ny2ECwnCAYT1Mw1/KmSSP2yENLOe20mu2t36yqDOw/M6ZhKrPZDSQrmprVim3e+w==",
-      "dev": true,
-      "dependencies": {
-        "annois": "^0.3.2",
-        "annotate": "^0.9.1"
       }
     },
     "node_modules/ansi-regex": {
@@ -2286,12 +2596,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/clone-function": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/clone-function/-/clone-function-1.0.6.tgz",
-      "integrity": "sha512-xI38lcQwn82379jMLIHwBKEhV4xItrSPB3tH9PC8TmEKzFlkj5zgwGcyzXN492GAtb2/IxDSjXellM0fdy3JwQ==",
-      "dev": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -5042,17 +5346,39 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/grunt-umd": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-umd/-/grunt-umd-3.0.0.tgz",
-      "integrity": "sha512-hrorGHjHv2EjN2DtZVqj5Y1KjX95RrdIuJlL5KyckArcw2UBijDOy0jrkauz1HTKSYUm7F0nUftLphjcexHTGw==",
+    "node_modules/grunt-shell": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-4.0.0.tgz",
+      "integrity": "sha512-dHFy8VZDfWGYLTeNvIHze4PKXGvIlDWuN0UE7hUZstTQeiEyv1VmW1MaDYQ3X5tE3bCi3bEia1gGKH8z/f1czQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "libumd": "^0.9.0",
-        "xtend": "^4.0.1"
+        "chalk": "^3.0.0",
+        "npm-run-path": "^2.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      },
+      "peerDependencies": {
+        "grunt": ">=1"
+      }
+    },
+    "node_modules/grunt-shell/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/grunt/node_modules/grunt-cli": {
@@ -5114,38 +5440,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/handlebars/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/has-flag": {
@@ -6141,20 +6435,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/libumd": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/libumd/-/libumd-0.9.0.tgz",
-      "integrity": "sha512-PU5h//kVK280bmayTQiuD2uxG9qY6DOk2zx/9xi93vhC5zCqow5mQn9wUSCBIUqycKFAUrk7T1sEC4wlxACtMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "alphabet": "^1.0.0",
-        "annois": "^0.3.2",
-        "annozip": "^0.2.6",
-        "handlebars": "^4.0.2",
-        "object-merge": "^2.5.1"
-      }
-    },
     "node_modules/liftup": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/liftup/-/liftup-3.0.1.tgz",
@@ -6990,13 +7270,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/netmask": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
@@ -7303,6 +7576,29 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/npmlog": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
@@ -7330,12 +7626,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/object-foreach": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/object-foreach/-/object-foreach-0.1.2.tgz",
-      "integrity": "sha512-q9B0lqCsKtLtvE00OvHR0RgiyRsNOk33wMI1g1NdVJLUlUI4CWfNHY8XUThuXpfxTbb/dut4yAYfNYDjiiBMtQ==",
-      "dev": true
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -7356,16 +7646,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object-merge": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/object-merge/-/object-merge-2.5.1.tgz",
-      "integrity": "sha512-kTM4Q/vbloBFJxfbEI0qW6gOJV78k8irJlr1R9l15dWOfAkxtjarevZJyXxJlAEUWuz1wa7ni7eRgVujP0m8TA==",
-      "dev": true,
-      "dependencies": {
-        "clone-function": ">=1.0.1",
-        "object-foreach": ">=0.1.2"
       }
     },
     "node_modules/object.assign": {
@@ -8818,6 +9098,51 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.0.tgz",
+      "integrity": "sha512-e5lPJi/aui4TO1LpAXIRLySmwXSE8k3b9zoGfd42p67wzxog4WHjiZF3M2uheQih4DGyc25QEV4yRBbpueNiUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.0",
+        "@rollup/rollup-android-arm64": "4.57.0",
+        "@rollup/rollup-darwin-arm64": "4.57.0",
+        "@rollup/rollup-darwin-x64": "4.57.0",
+        "@rollup/rollup-freebsd-arm64": "4.57.0",
+        "@rollup/rollup-freebsd-x64": "4.57.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.0",
+        "@rollup/rollup-linux-arm64-musl": "4.57.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.0",
+        "@rollup/rollup-linux-loong64-musl": "4.57.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.0",
+        "@rollup/rollup-linux-x64-gnu": "4.57.0",
+        "@rollup/rollup-linux-x64-musl": "4.57.0",
+        "@rollup/rollup-openbsd-x64": "4.57.0",
+        "@rollup/rollup-openharmony-arm64": "4.57.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.0",
+        "@rollup/rollup-win32-x64-gnu": "4.57.0",
+        "@rollup/rollup-win32-x64-msvc": "4.57.0",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {
@@ -10522,13 +10847,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,17 @@
     "lib": "./src/",
     "example": "./examples/"
   },
+  "type": "commonjs",
   "main": "dist/rasterizeHTML.js",
+  "module": "dist/rasterizeHTML.mjs",
   "types": "dist/rasterizeHTML.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/rasterizeHTML.mjs",
+      "require": "./dist/rasterizeHTML.js",
+      "default": "./dist/rasterizeHTML.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/cburgmer/rasterizeHTML.js.git"
@@ -43,7 +52,8 @@
     "grunt-contrib-uglify": "^5.0.1",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-eslint": "^26.0.0",
-    "grunt-umd": "^3.0.0",
+    "grunt-shell": "^4.0.0",
+    "rollup": "^4.40.0",
     "imagediff": "git://github.com/HumbleSoftware/js-imagediff.git#5edce005fe",
     "jasmine-core": "^5.13.0",
     "prettier": "^3.7.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,48 @@
+const pkg = require("./package.json");
+
+const today = new Date().toISOString().split("T")[0];
+const year = new Date().getFullYear();
+
+const banner = `/*! ${pkg.title || pkg.name} - v${pkg.version} - ${today}
+* ${pkg.homepage}
+* Copyright (c) ${year} ${pkg.author.name}; Licensed ${pkg.license} */`;
+
+module.exports = [
+    // UMD build (for browsers and CommonJS)
+    {
+        input: "build/rasterizeHTML.concat.js",
+        output: {
+            file: "dist/rasterizeHTML.js",
+            format: "umd",
+            name: "rasterizeHTML",
+            banner,
+            globals: {
+                url: "url",
+                xmlserializer: "xmlserializer",
+                "sane-domparser-error": "sanedomparsererror",
+                inlineresources: "inlineresources",
+            },
+        },
+        external: [
+            "url",
+            "xmlserializer",
+            "sane-domparser-error",
+            "inlineresources",
+        ],
+    },
+    // ESM build
+    {
+        input: "build/rasterizeHTML.concat.js",
+        output: {
+            file: "dist/rasterizeHTML.mjs",
+            format: "es",
+            banner,
+        },
+        external: [
+            "url",
+            "xmlserializer",
+            "sane-domparser-error",
+            "inlineresources",
+        ],
+    },
+];


### PR DESCRIPTION
Publish library as ESM. This PR adds Rollup as a bundler which runs `build/rasterizeHTML.concat.js` through a transpile step that outputs ESM and UMD (to ensure backward compatibility). 

The UMD export is available at `dist/rasterizeHTML.js`. You can see that it contains code at the top to check for `module.exports` (CJS), `define` (for AMD) and ultimately sets `window.rasterizeHTML` if none of the first conditions pass.

The ESM bundle is available at `dist/rasterizeHTML.mjs`. 

This isn't a breaking change as I've intentionally left the output paths the same. `dist/rasterizeHTML.js` is still UMD as before. The only addition is that we now have a `dist/rasterizeHTML.mjs` which is an ESM build.

I've also intentionally left the minified bundles (and added one for ESM). We can remove this when we do breaking changes as it isn't necessary. For users who want to minify, it makes more sense to do it when bundling the application that includes this library instead of including the minified library. 

To test this, I've created [this branch](https://github.com/bernardobelchior/rasterizeHTML.js/tree/rollup-build-tester) that contains a Webpack application to test ESM, UMD and CJS. Importing ESM directly (e.g., using `<script type="module">` plus import maps) doesn't work because the dependencies of `rasterizeHTML` aren't published as ESM. You can test this method by opening this [index.html](https://github.com/bernardobelchior/rasterizeHTML.js/blob/rollup-build-tester/test-integration/index.html) (doesn't require a webpack build, unlike the other options).

Let me know if you have any questions. I'm diffed the current and new output and everything seems fine, but I'm not an expert in JS module systems, so something might be wrong. 